### PR TITLE
refactor `sq.gr.moran`, remove pysal depend

### DIFF
--- a/squidpy/gr/_ppatterns.py
+++ b/squidpy/gr/_ppatterns.py
@@ -1,7 +1,6 @@
 """Functions for point patterns spatial statistics."""
 from typing import Any, Tuple, Union, Iterable, Optional, Sequence
 from itertools import chain
-import warnings
 
 from scanpy import logging as logg
 from anndata import AnnData
@@ -25,18 +24,6 @@ from squidpy.gr._utils import (
     _assert_non_empty_sequence,
 )
 from squidpy._constants._pkg_constants import Key
-
-try:
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", UserWarning)
-        from libpysal.weights import W
-        import esda
-        import libpysal
-except ImportError:
-    esda = None
-    libpysal = None
-    W = None
-
 
 __all__ = ["ripley_k", "moran", "co_occurrence"]
 

--- a/squidpy/gr/_ppatterns.py
+++ b/squidpy/gr/_ppatterns.py
@@ -254,7 +254,6 @@ def _compute_moran(
         i_indices = indices[s]
         i_data = data[s]
         zl[i] = np.sum(i_data * z[i_indices])
-    # zl = adj * z
     inum = (z * zl).sum()
     z2ss = (z * z).sum()
     return len(counts) / data.sum() * inum / z2ss

--- a/squidpy/gr/_ppatterns.py
+++ b/squidpy/gr/_ppatterns.py
@@ -218,7 +218,7 @@ def _moran_helper(
 
     moran_list = []
     for g in gen:
-        counts = adata.obs_vector(g, layer=layer).copy().astype(fp)
+        counts = adata.obs_vector(g, layer=layer).astype(fp, copy=True)
         indptr = adj.indptr.astype(ip)
         indices = adj.indices.astype(ip)
         data = adj.data.astype(fp)


### PR DESCRIPTION
### Types of changes
<!--- What types of changes are introduced? Put an `x` in all applicable boxes: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (change that would cause existing functionality to not work as before)
- [x] New feature (non-breaking change which adds functionality)

### Description
Re-implement Moran's I to remove libpysal dependency

### How has this been tested?
not yet

### Closes

TODO:

- [ ] add row wise transform?
- [ ] improve speed ?
- [ ] change docs and reference

@michalk8 implementation is really trivial see [wiki](https://en.wikipedia.org/wiki/Moran%27s_I) and original code https://github.com/pysal/esda/blob/642880e0b49913de07e5b7fafb3dd0b5855ed2ef/esda/moran.py#L234

unfortunately, it's slower than original, not sure why. one interpretation could be that numba vectorized dot product is still slower than `np.dot` and the gain in permutation is lost. do you see any major performance issues? otherwise could also revert to plain numpy.
anyway, this will allow us to remove pysal+esda from dependency. top 100 genes by pysal are consistent
![image](https://user-images.githubusercontent.com/25887487/110706661-81885480-81f8-11eb-8a1b-57010b76eb0a.png)
