### PR TITLE
enable visualisation of images with variable scale

### DIFF
--- a/squidpy/im/_container.py
+++ b/squidpy/im/_container.py
@@ -80,6 +80,9 @@ class ImageContainer(FeatureMixin):
     Parameters
     ----------
     %(add_img.parameters)s
+    scale
+        Scalefactor of the image with respect to the spatial coords saved in
+        the accompanying :class:`ad.AnnData`.
 
     Raises
     ------
@@ -90,12 +93,13 @@ class ImageContainer(FeatureMixin):
         self,
         img: Optional[Input_t] = None,
         layer: str = "image",
+        scale: float = 1.0,
         **kwargs: Any,
     ):
         self._data: xr.Dataset = xr.Dataset()
         self._data.attrs[Key.img.coords] = _NULL_COORDS  # can't save None to NetCDF
         self._data.attrs[Key.img.padding] = _NULL_PADDING
-        self._data.attrs[Key.img.scale] = 1
+        self._data.attrs[Key.img.scale] = scale
         self._data.attrs[Key.img.mask_circle] = False
 
         chunks = kwargs.pop("chunks", None)
@@ -246,7 +250,7 @@ class ImageContainer(FeatureMixin):
 
         suffix = img.suffix.lower()
 
-        if suffix in (".jpg", ".jpeg"):
+        if suffix in (".jpg", ".jpeg", ".png"):
             return self._load_img(imread(str(img)))
 
         if img.is_dir():

--- a/squidpy/pl/_interactive/_model.py
+++ b/squidpy/pl/_interactive/_model.py
@@ -35,6 +35,8 @@ class ImageModel:
     def __post_init__(self) -> None:
         self.symbol = Symbol(self.symbol)
         self.coordinates = self.adata.obsm[self.spatial_key][:, ::-1]
+        self.library_id = Key.uns.library_id(self.adata, self.spatial_key, self.library_id)
+        self.spot_diameter = Key.uns.spot_diameter(self.adata, self.spatial_key, self.library_id)
 
         if self.container.data.attrs.get("coords", _NULL_COORDS) != _NULL_COORDS:
             c: CropCoords = self.container.data.attrs["coords"]
@@ -52,6 +54,10 @@ class ImageModel:
             self.coordinates[:, 0] -= c.x0
             self.coordinates[:, 1] -= c.y0
 
+        if self.container.data.attrs.get("scale", 1) != 1:
+            s = self.container.data.attrs["scale"]
+            # update coordinates with image scale
+            self.coordinates = self.coordinates.copy() * s
+            self.spot_diameter = Key.uns.spot_diameter(self.adata, self.spatial_key, self.library_id) * s
+
         self.alayer = ALayer(self.adata, is_raw=False, palette=self.palette)
-        self.library_id = Key.uns.library_id(self.adata, self.spatial_key, self.library_id)
-        self.spot_diameter = Key.uns.spot_diameter(self.adata, self.spatial_key, self.library_id)


### PR DESCRIPTION
### Types of changes
<!--- What types of changes are introduced? Put an `x` in all applicable boxes: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (change that would cause existing functionality to not work as before)
- [x] New feature (non-breaking change which adds functionality)

### Description
<!--- What does this PR achieve? -->
if an ImageContainer is downscaled, currently interactive visualisation does not work as expected.
This PR fixes this by changing the Interactive to respect image scale stored in `img.data.attrs['scale']`.
In addition, a scale kwarg was added to `ImageContainer.add_img`.

### How has this been tested?
<!--- Describe how you've tested your changes: -->
needs a test

### Closes
<!--- If applicable, add `closes #XXXX` below to auto-close the issue related to this PR: -->
...
