### PR TITLE
Fix napari for multiple library_ids

### DIFF
--- a/squidpy/im/_container.py
+++ b/squidpy/im/_container.py
@@ -541,7 +541,8 @@ class ImageContainer(FeatureMixin):
 
         if scale != 1:
             attrs = data.attrs
-            data = data.map(_rescale)
+            library_ids = data.coords["z"]
+            data = data.map(_rescale).assign_coords({"z": library_ids})
             data.attrs = _update_attrs_scale(attrs, scale)
 
         if mask_circle:

--- a/squidpy/pl/_interactive/_controller.py
+++ b/squidpy/pl/_interactive/_controller.py
@@ -115,13 +115,14 @@ class ImageController:
         -------
         `True` if the layer has been added, otherwise `False`.
         """
-        img: xr.DataArray = self.model.container.data[layer].transpose("z", ..., "y", "x")
+        # beware `update_library` in view.py - needs to be in this order
+        img: xr.DataArray = self.model.container.data[layer].transpose(..., "z", "y", "x")
         if img.ndim != 4:
             logg.warning(f"Unable to show image of shape `{img.shape}`, too many dimensions")
             return False
 
-        if img.shape[1] != 1:
-            logg.warning(f"Unable to create labels layer of shape `{img.shape}`, too many channels `{img.shape[1]}`")
+        if img.shape[0] != 1:
+            logg.warning(f"Unable to create labels layer of shape `{img.shape}`, too many channels `{img.shape[0]}`")
             return False
 
         if not np.issubdtype(img.dtype, np.integer):

--- a/squidpy/pl/_interactive/_model.py
+++ b/squidpy/pl/_interactive/_model.py
@@ -41,7 +41,6 @@ class ImageModel:
         self.adata = self.container._subset(self.adata, spatial_key=self.spatial_key, adjust_interactive=True)
         if not self.adata.n_obs:
             raise ValueError("No spots were selected. Please ensure that the image contains at least 1 spot.")
-
         self.coordinates = self.adata.obsm[self.spatial_key][:, ::-1][:, :2].copy()
         self.scale = self.container.data.attrs.get(Key.img.scale, 1)
         self._update_coords()
@@ -97,7 +96,9 @@ class ImageModel:
 
         self.coordinates = np.c_[libraries.cat.codes.values, self.coordinates[mask]]
 
-        self.spot_diameter = (
-            np.array([0.0] + [Key.uns.spot_diameter(self.adata, self.spatial_key, lid) for lid in self.library_id])
-            * self.scale
-        )
+        self.spot_diameter = np.array(
+            [
+                np.array([0.0] + [Key.uns.spot_diameter(self.adata, self.spatial_key, lid)] * 2) * self.scale
+                for lid in libraries
+            ]
+        )  # TODO spot_diameter needs to be 3d, and is potentially different for different library ids


### PR DESCRIPTION
### Types of changes
<!--- What types of changes are introduced? Put an `x` in all applicable boxes: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (change that would cause existing functionality to not work as before)
- [ ] New feature (non-breaking change which adds functionality)

### Description
- fix missing library id when rescaling image crops
- fix wrong spot_diameter in napari. There was a bug in the code that lead to napari only working with 2 library_ids. 

### How has this been tested?
<!--- Describe how you've tested your changes: -->
...

### Closes
<!--- If applicable, add `closes #XXXX` below to auto-close the issue related to this PR: -->
...
