### PR TITLE
Delaunay optimization

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.1
+current_version = 1.1.0
 commit = True
 tag = True
 files = setup.py squidpy/__init__.py

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ except ImportError:
             "hannah.spitzer@helmholtz-muenchen.de",
         ]
     )
-    __version__ = "1.0.1"
+    __version__ = "1.1.0"
 
 setup(
     name="squidpy",

--- a/squidpy/__init__.py
+++ b/squidpy/__init__.py
@@ -5,7 +5,7 @@ __email__ = ", ".join(
         "hannah.spitzer@helmholtz-muenchen.de",
     ]
 )
-__version__ = "1.0.1"
+__version__ = "1.1.0"
 
 from squidpy import datasets
 import squidpy.gr

--- a/squidpy/gr/_build.py
+++ b/squidpy/gr/_build.py
@@ -184,8 +184,7 @@ def _build_connectivity(
             for i in np.arange(N):
                 dists_lst.append(
                     euclidean_distances(
-                        coords[conns_m.indices[conns_m.indptr[i]:conns_m.indptr[i+1]], :], 
-                        coords[np.newaxis, i, :]
+                        coords[conns_m.indices[conns_m.indptr[i] : conns_m.indptr[i + 1]], :], coords[np.newaxis, i, :]
                     )
                 )
 
@@ -216,7 +215,7 @@ def _build_connectivity(
 
         if return_distance:
             dists_m = csr_matrix((dists, (row_indices, col_indices)), shape=(N, N))
-    
+
     if set_diag:
         conns_m.setdiag(1)
 

--- a/squidpy/gr/_build.py
+++ b/squidpy/gr/_build.py
@@ -175,25 +175,23 @@ def _build_connectivity(
     dists_m = None
     if delaunay:
         tri = Delaunay(coords)
-        col_lst = []
-        row_lst = []
-        dists_lst = []
-        for i in np.arange(N):
-            idx = np.argwhere(i == tri.simplices)[:, 0]
-            idx_col = np.unique(np.setdiff1d(tri.simplices[idx.squeeze(), ...], i)).tolist()
-            col_lst.append(idx_col)
-            row_lst.append(np.repeat(i, len(idx_col)))
-            dists_lst.append(
-                euclidean_distances(
-                    coords[idx_col, :],
-                    coords[np.newaxis, i, :],
+
+        indptr, indices = tri.vertex_neighbor_vertices
+        conns_m = csr_matrix((np.ones(len(indices)), indices, indptr), shape=(N, N))
+
+        if return_distance:
+            dists_lst = []
+            for i in np.arange(N):
+                dists_lst.append(
+                    euclidean_distances(
+                        coords[conns_m.indices[conns_m.indptr[i]:conns_m.indptr[i+1]], :], 
+                        coords[np.newaxis, i, :]
+                    )
                 )
-            )
 
-        col_indices = np.array(list(chain(*col_lst)))
-        row_indices = np.array(list(chain(*row_lst)))
-        dists = np.array(list(chain(*dists_lst))).squeeze()
+            dists = np.array(list(chain(*dists_lst))).squeeze()
 
+            dists_m = csr_matrix((dists, indices, indptr), shape=(N, N))
     else:
         tree = NearestNeighbors(n_neighbors=n_neighbors, radius=radius or 1, metric="euclidean")
         tree.fit(coords)
@@ -214,14 +212,13 @@ def _build_connectivity(
                 row_indices, col_indices = row_indices[mask], col_indices[mask]
                 dists = dists[mask]
 
-    if return_distance:
-        dists_m = csr_matrix((dists, (row_indices, col_indices)), shape=(N, N))
+        conns_m = csr_matrix((np.ones(len(row_indices)), (row_indices, col_indices)), shape=(N, N))
 
+        if return_distance:
+            dists_m = csr_matrix((dists, (row_indices, col_indices)), shape=(N, N))
+    
     if set_diag:
-        row_indices = np.concatenate((row_indices, np.arange(N)))
-        col_indices = np.concatenate((col_indices, np.arange(N)))
-
-    conns_m = csr_matrix((np.ones(len(row_indices)), (row_indices, col_indices)), shape=(N, N))
+        conns_m.setdiag(1)
 
     return (conns_m, dists_m) if return_distance else conns_m
 


### PR DESCRIPTION
### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (change that would cause existing functionality to not work as before)
- [ ] New feature (non-breaking change which adds functionality)

### Description
In the computation of the spatial graph from the Delaunay triangulation, the code to obtain the list of rows and columns is unnecessary given that they are already computed by `scipy.spatial.Delaunay` and thus stored into `tri.vertex_neighbor_vertices`.
The connections are already in a format suitable for the csr_matrix.

Since the building of the csr_matrix between the two methods (delaunay vs. nearest neighbor) is now different I replaced the way of setting the diagonal elements in the case of `set_diag=True` into a way that is independent of how the matrix is built.

The modification results in a speed-up of the `gr.spatial_neighbors` function from:
`928 ms ± 9.53 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)`

to
`46 ms ± 2.28 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)`

on the `sq.datasets.visium_fluo_adata` dataset with 2800 observations.

### How has this been tested?
The modifications replace an existing piece of code without adding functionalities and the previous version didn't actually contain a bug, so I only run the `test_spatial_connectivity.py` test.

