### PR TITLE
Fix reading tiffs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,6 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             fail-fast: false
-            max-parallel: 4
             matrix:
                 python: [3.7, 3.8]
                 os: [ubuntu-latest, macos-latest]

--- a/tests/image/test_container.py
+++ b/tests/image/test_container.py
@@ -90,7 +90,8 @@ class TestContainerIO:
         img2 = ImageContainer.load(Path(tmpdir) / "foo")
 
         np.testing.assert_array_equal(img["image"].values, img2["image"].values)
-        np.testing.assert_array_equal(img.data.dims, img2.data.dims)
+        np.testing.assert_array_equal(img["image"].dims, img2["image"].dims)
+        assert img.data.dims == img2.data.dims
         np.testing.assert_array_equal(sorted(img.data.attrs.keys()), sorted(img2.data.attrs.keys()))
         for k, v in img.data.attrs.items():
             assert type(v) == type(img2.data.attrs[k])  # noqa: E721


### PR DESCRIPTION
### Types of changes
<!--- What types of changes are introduced? Put an `x` in all applicable boxes: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (change that would cause existing functionality to not work as before)
- [ ] New feature (non-breaking change which adds functionality)

### Description
<!--- What does this PR achieve? -->
Fix loading `TIFFs`: problem was that `tifffile.imread` returned `(y, x, z)`, whereas we expected `(z, y, x)` + reshape from
the former into latter caused the artifacts in #389 .
Also fixes passing explicit dimnames to 3D arrays when loading from files.
TODO: fix linting

In the future, switch to e.g. `dask_image.read` for either TIFFs only or for all image types once `pims` (backend for their IO) allows lazy loading if JPEGs.
Also, consider (in the future) refactoring our IO to some `Dimension` class (will be very useful/almost necessary) when adding new dimension to `ImageContainer`.

### How has this been tested?
<!--- Describe how you've tested your changes: -->
TODO: 2 tests 
1. one that tests setting `dims` explicitly for 3D image on disk
2. one that tries to load a `.tifffile` similar to the one in #389 

### Closes
<!--- If applicable, add `closes #XXXX` below to auto-close the issue related to this PR: -->
closes #389 
