### PR TITLE
Have gr._utils._check_tuple_needles error message report correct string if invalid cluster name supplied.

### DIFF
--- a/squidpy/gr/_utils.py
+++ b/squidpy/gr/_utils.py
@@ -41,7 +41,7 @@ def _check_tuple_needles(
                 continue
         if b not in haystack:
             if reraise:
-                raise ValueError(msg.format(a))
+                raise ValueError(msg.format(b))
             else:
                 continue
 


### PR DESCRIPTION
## Description
`squidpy.gr._ligrec._check_tuple_needles` has an error message when invalid cluster names are passed to it through `squidpy.gr._ligrec`, which reads ""Invalid cluster `<Bad Cluster>`.", but if the invalid one is the second object of the tuple, the error message will print the first object of the tuple. This fix should give the correct error message now.

## How has this been tested?
```
from itertools import product
clusters = list(map(str, adata_parent.obs["leiden_coarse"].cat.categories))
clusters.append("bad one")
clusters = list(product(clusters, repeat=2))  # type: ignore[no-redef,assignment]
clusters = sorted(
            sp.gr._ligrec._check_tuple_needles(
                clusters,  # type: ignore[arg-type]
                adata_parent.obs["leiden_coarse"].cat.categories,
                msg="Invalid cluster `{0!r}`.",
                reraise=True,
            )
        )
```
Before: ValueError: Invalid cluster `'APC'`. [ this is a real cluster in my data ]
After: ValueError: Invalid cluster `'bad one'`.
