### PR TITLE
Add type stubs to datasets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
     hooks:
     -   id: mypy
         additional_dependencies: [numpy==1.21.0, scipy, pandas, types-requests]
+        exclude: squidpy/datasets/_(dataset|image).py   # See https://github.com/pre-commit/mirrors-mypy/issues/33
 -   repo: https://github.com/psf/black
     rev: 22.1.0
     hooks:

--- a/squidpy/datasets/_dataset.pyi
+++ b/squidpy/datasets/_dataset.pyi
@@ -1,0 +1,15 @@
+from typing import Callable
+
+from anndata import AnnData
+
+four_i: Callable[[], AnnData]
+imc: Callable[[], AnnData]
+seqfish: Callable[[], AnnData]
+visium_hne_adata: Callable[[], AnnData]
+visium_hne_adata_crop: Callable[[], AnnData]
+visium_fluo_adata: Callable[[], AnnData]
+visium_fluo_adata_crop: Callable[[], AnnData]
+sc_mouse_cortex: Callable[[], AnnData]
+mibitof: Callable[[], AnnData]
+merfish: Callable[[], AnnData]
+slideseqv2: Callable[[], AnnData]

--- a/squidpy/datasets/_dataset.pyi
+++ b/squidpy/datasets/_dataset.pyi
@@ -1,17 +1,20 @@
-from typing import Any, Callable
+from typing import Any, Union, Protocol
 
 from anndata import AnnData
 
 from squidpy.datasets._utils import PathLike
 
-four_i: Callable[[PathLike, Any], AnnData]
-imc: Callable[[PathLike, Any], AnnData]
-seqfish: Callable[[PathLike, Any], AnnData]
-visium_hne_adata: Callable[[PathLike, Any], AnnData]
-visium_hne_adata_crop: Callable[[PathLike, Any], AnnData]
-visium_fluo_adata: Callable[[PathLike, Any], AnnData]
-visium_fluo_adata_crop: Callable[[PathLike, Any], AnnData]
-sc_mouse_cortex: Callable[[PathLike, Any], AnnData]
-mibitof: Callable[[PathLike, Any], AnnData]
-merfish: Callable[[PathLike, Any], AnnData]
-slideseqv2: Callable[[PathLike, Any], AnnData]
+class Dataset(Protocol):
+    def __call__(self, path: Union[PathLike, None] = ..., **kwargs: Any) -> AnnData: ...
+
+four_i: Dataset
+imc: Dataset
+seqfish: Dataset
+visium_hne_adata: Dataset
+visium_hne_adata_crop: Dataset
+visium_fluo_adata: Dataset
+visium_fluo_adata_crop: Dataset
+sc_mouse_cortex: Dataset
+mibitof: Dataset
+merfish: Dataset
+slideseqv2: Dataset

--- a/squidpy/datasets/_dataset.pyi
+++ b/squidpy/datasets/_dataset.pyi
@@ -1,15 +1,17 @@
-from typing import Callable
+from typing import Any, Callable
 
 from anndata import AnnData
 
-four_i: Callable[[], AnnData]
-imc: Callable[[], AnnData]
-seqfish: Callable[[], AnnData]
-visium_hne_adata: Callable[[], AnnData]
-visium_hne_adata_crop: Callable[[], AnnData]
-visium_fluo_adata: Callable[[], AnnData]
-visium_fluo_adata_crop: Callable[[], AnnData]
-sc_mouse_cortex: Callable[[], AnnData]
-mibitof: Callable[[], AnnData]
-merfish: Callable[[], AnnData]
-slideseqv2: Callable[[], AnnData]
+from squidpy.datasets._utils import PathLike
+
+four_i: Callable[[PathLike, Any], AnnData]
+imc: Callable[[PathLike, Any], AnnData]
+seqfish: Callable[[PathLike, Any], AnnData]
+visium_hne_adata: Callable[[PathLike, Any], AnnData]
+visium_hne_adata_crop: Callable[[PathLike, Any], AnnData]
+visium_fluo_adata: Callable[[PathLike, Any], AnnData]
+visium_fluo_adata_crop: Callable[[PathLike, Any], AnnData]
+sc_mouse_cortex: Callable[[PathLike, Any], AnnData]
+mibitof: Callable[[PathLike, Any], AnnData]
+merfish: Callable[[PathLike, Any], AnnData]
+slideseqv2: Callable[[PathLike, Any], AnnData]

--- a/squidpy/datasets/_image.pyi
+++ b/squidpy/datasets/_image.pyi
@@ -1,0 +1,7 @@
+from typing import Callable
+
+from squidpy.im._container import ImageContainer
+
+visium_fluo_image_crop: Callable[[], ImageContainer]
+visium_hne_image_crop: Callable[[], ImageContainer]
+visium_hne_image: Callable[[], ImageContainer]

--- a/squidpy/datasets/_image.pyi
+++ b/squidpy/datasets/_image.pyi
@@ -1,7 +1,8 @@
-from typing import Callable
+from typing import Any, Callable
 
 from squidpy.im._container import ImageContainer
+from squidpy.datasets._utils import PathLike
 
-visium_fluo_image_crop: Callable[[], ImageContainer]
-visium_hne_image_crop: Callable[[], ImageContainer]
-visium_hne_image: Callable[[], ImageContainer]
+visium_fluo_image_crop: Callable[[PathLike, Any], ImageContainer]
+visium_hne_image_crop: Callable[[PathLike, Any], ImageContainer]
+visium_hne_image: Callable[[PathLike, Any], ImageContainer]

--- a/squidpy/datasets/_image.pyi
+++ b/squidpy/datasets/_image.pyi
@@ -1,8 +1,11 @@
-from typing import Any, Callable
+from typing import Any, Union, Protocol
 
 from squidpy.im._container import ImageContainer
 from squidpy.datasets._utils import PathLike
 
-visium_fluo_image_crop: Callable[[PathLike, Any], ImageContainer]
-visium_hne_image_crop: Callable[[PathLike, Any], ImageContainer]
-visium_hne_image: Callable[[PathLike, Any], ImageContainer]
+class ImageDataset(Protocol):
+    def __call__(self, path: Union[PathLike, None] = ..., **kwargs: Any) -> ImageContainer: ...
+
+visium_fluo_image_crop: ImageDataset
+visium_hne_image_crop: ImageDataset
+visium_hne_image: ImageDataset


### PR DESCRIPTION
## Description
Add type stubs to datasets.

## How has this been tested?
Pre-commit and test suites
Note the need to exclude original *.py files from the mypy pre-commit due to pre-commit/mirrors-mypy#33. A solution to maintain type safety would be to add a full mypy/pyright step to the CI workflow.