### PR TITLE
Check dims for backwards compatibility of image loading

### DIFF
--- a/squidpy/im/_container.py
+++ b/squidpy/im/_container.py
@@ -336,7 +336,7 @@ class ImageContainer(FeatureMixin):
     ) -> xr.DataArray | None:
         def transform_metadata(data: xr.Dataset) -> xr.Dataset:
             for img in data.values():
-                _assert_dims_present(img.dims)
+                _assert_dims_present(img.dims, include_z=len(img.dims) == 4)
 
             data.attrs[Key.img.coords] = CropCoords.from_tuple(data.attrs.get(Key.img.coords, _NULL_COORDS.to_tuple()))
             data.attrs[Key.img.padding] = CropPadding.from_tuple(


### PR DESCRIPTION

**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Description
<!-- Clearly and concisely describe your changes. This section will be shown in the docs. -->
Include check to be able to load ImageContainer that were generated from another version of squidpy.

## How has this been tested?
<!-- Describe in detail how you've tested your changes. -->
Fixes loading of ImageContainer for me, see #507. 
## Closes
<!-- If applicable, type `closes #XXXX` in your comment to auto-close the issue that this PR fixes. -->
#507 