### PR TITLE
Fix typo in save_fig: Path -> path

### DIFF
--- a/squidpy/pl/_utils.py
+++ b/squidpy/pl/_utils.py
@@ -82,9 +82,9 @@ def save_fig(fig: Figure, path: str | Path, make_dir: bool = True, ext: str = "p
 
     if make_dir:
         try:
-            os.makedirs(str(Path.parent), exist_ok=True)
+            path.parent.mkdir(parents=True, exist_ok=True)
         except OSError as e:
-            logg.debug(f"Unable to create directory `{Path.parent}`. Reason: `{e}`")
+            logg.debug(f"Unable to create directory `{path.parent}`. Reason: `{e}`")
 
     logg.debug(f"Saving figure to `{path!r}`")
 


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Description
<!-- Clearly and concisely describe your changes. This section will be shown in the docs. -->
Fix a typo when saving a figure caused a strange directory name to be created.

## How has this been tested?
<!-- Describe in detail how you've tested your changes. -->
N/A

## Closes
<!-- If applicable, type `closes #XXXX` in your comment to auto-close the issue that this PR fixes. -->
closes #505