### PR TITLE
Make `spot_diameter` more flexible

### DIFF
--- a/squidpy/_constants/_pkg_constants.py
+++ b/squidpy/_constants/_pkg_constants.py
@@ -124,7 +124,7 @@ class Key:
             adata: AnnData,
             spatial_key: str,
             library_id: Optional[str] = None,
-            spot_diameter_key: Optional[str] = "spot_diameter_fullres",
+            spot_diameter_key: str = "spot_diameter_fullres",
         ) -> float:
             try:
                 return float(adata.uns[spatial_key][library_id]["scalefactors"][spot_diameter_key])

--- a/squidpy/_constants/_pkg_constants.py
+++ b/squidpy/_constants/_pkg_constants.py
@@ -119,13 +119,19 @@ class Key:
             return library_id
 
         @classmethod
-        def spot_diameter(cls, adata: AnnData, spatial_key: str, library_id: Optional[str] = None) -> float:
+        def spot_diameter(
+            cls,
+            adata: AnnData,
+            spatial_key: str,
+            library_id: Optional[str] = None,
+            spot_diameter_key: Optional[str] = "spot_diameter_fullres",
+        ) -> float:
             try:
-                return float(adata.uns[spatial_key][library_id]["scalefactors"]["spot_diameter_fullres"])
+                return float(adata.uns[spatial_key][library_id]["scalefactors"][spot_diameter_key])
             except KeyError:
                 raise KeyError(
                     f"Unable to get the spot diameter from "
-                    f"`adata.uns[{spatial_key!r}][{library_id!r}]['scalefactors']['spot_diameter_fullres']]`"
+                    f"`adata.uns[{spatial_key!r}][{library_id!r}]['scalefactors'][{spot_diameter_key!r}]]`"
                 ) from None
 
     class obsp:

--- a/squidpy/im/_container.py
+++ b/squidpy/im/_container.py
@@ -715,6 +715,7 @@ class ImageContainer(FeatureMixin):
         adata: AnnData,
         spatial_key: str = Key.obsm.spatial,
         library_id: str | None = None,
+        spot_diameter_key: str = "spot_diameter_fullres",
         spot_scale: float = 1.0,
         obs_names: Iterable[Any] | None = None,
         as_array: str | bool = False,
@@ -736,6 +737,8 @@ class ImageContainer(FeatureMixin):
         %(adata)s
         %(spatial_key)s
         %(img_library_id)s
+        spot_diameter_key
+            Keyword under which the spot diameter in stored (px).
         spot_scale
             Scaling factor for the spot diameter. Larger values mean more context.
         obs_names
@@ -799,11 +802,13 @@ class ImageContainer(FeatureMixin):
         if adata.n_obs != len(obs_library_ids):
             raise ValueError(f"Expected library ids to be of length `{adata.n_obs}`, found `{len(obs_library_ids)}`.")
 
-        sid = kwargs.pop("spot_diameter_key", "spot_diameter_fullres")
         for i, (obs, lid) in enumerate(zip(adata.obs_names, obs_library_ids)):
             # get spot diameter of current obs (might be different library ids)
             diameter = (
-                Key.uns.spot_diameter(adata, spatial_key=spatial_key, library_id=lid, spot_diameter_key=sid) * scale
+                Key.uns.spot_diameter(
+                    adata, spatial_key=spatial_key, library_id=lid, spot_diameter_key=spot_diameter_key
+                )
+                * scale
             )
             radius = int(round(diameter // 2 * spot_scale))
 

--- a/squidpy/im/_container.py
+++ b/squidpy/im/_container.py
@@ -799,9 +799,12 @@ class ImageContainer(FeatureMixin):
         if adata.n_obs != len(obs_library_ids):
             raise ValueError(f"Expected library ids to be of length `{adata.n_obs}`, found `{len(obs_library_ids)}`.")
 
+        sid = kwargs.pop("spot_diameter_key", "spot_diameter_fullres")
         for i, (obs, lid) in enumerate(zip(adata.obs_names, obs_library_ids)):
             # get spot diameter of current obs (might be different library ids)
-            diameter = Key.uns.spot_diameter(adata, spatial_key=spatial_key, library_id=lid) * scale
+            diameter = (
+                Key.uns.spot_diameter(adata, spatial_key=spatial_key, library_id=lid, spot_diameter_key=sid) * scale
+            )
             radius = int(round(diameter // 2 * spot_scale))
 
             # get coords in image pixel space from original space

--- a/squidpy/im/_container.py
+++ b/squidpy/im/_container.py
@@ -738,7 +738,8 @@ class ImageContainer(FeatureMixin):
         %(spatial_key)s
         %(img_library_id)s
         spot_diameter_key
-            Keyword under which the spot diameter in stored (px).
+            Key in :attr:`anndata.AnnData.uns` ``['{spatial_key}']['{library_id}']['scalefactors']``
+            where the spot diameter is stored.
         spot_scale
             Scaling factor for the spot diameter. Larger values mean more context.
         obs_names

--- a/squidpy/pl/_interactive/_model.py
+++ b/squidpy/pl/_interactive/_model.py
@@ -26,6 +26,7 @@ class ImageModel:
     spatial_key: str = field(default=Key.obsm.spatial, repr=False)
     library_key: str | None = None
     library_id: str | Sequence[str] | None = None
+    spot_diameter_key: str = "spot_diameter_fullres"
     spot_diameter: NDArrayA | float = field(default=0, init=False)
     coordinates: NDArrayA = field(init=False, repr=False)
     alayer: ALayer = field(init=False, repr=True)
@@ -76,7 +77,10 @@ class ImageModel:
             self.library_id = self.container.library_ids
             if TYPE_CHECKING:
                 assert isinstance(self.library_id, Sequence)
-            self.spot_diameter = Key.uns.spot_diameter(self.adata, self.spatial_key, self.library_id[0]) * self.scale
+            self.spot_diameter = (
+                Key.uns.spot_diameter(self.adata, self.spatial_key, self.library_id[0], self.spot_diameter_key)
+                * self.scale
+            )
             return
 
         _assert_categorical_obs(self.adata, self.library_key)
@@ -99,7 +103,8 @@ class ImageModel:
         self.coordinates = np.c_[libraries.cat.codes.values, self.coordinates[mask]]
         self.spot_diameter = np.array(
             [
-                np.array([0.0] + [Key.uns.spot_diameter(self.adata, self.spatial_key, lid)] * 2) * self.scale
+                np.array([0.0] + [Key.uns.spot_diameter(self.adata, self.spatial_key, lid, self.spot_diameter_key)] * 2)
+                * self.scale
                 for lid in libraries
             ]
         )

--- a/tests/image/test_container.py
+++ b/tests/image/test_container.py
@@ -569,6 +569,13 @@ class TestContainerCropping:
 
             np.testing.assert_array_equal(crop["image"].values[..., 0][~mask.values], np.nan)
 
+    @pytest.mark.parametrize("diameter", [13, 17])
+    def test_spot_crops_diameter(self, adata: AnnData, cont: ImageContainer, diameter: int):
+        adata.uns[Key.uns.spatial] = {"bar": {"scalefactors": {"foo": diameter}}}
+        for crop in cont.generate_spot_crops(adata, spot_diameter_key="foo"):
+            assert crop.shape[0] == crop.shape[1]
+            assert crop.shape[0] == diameter
+
     def test_uncrop_preserves_shape(self, small_cont_1c: ImageContainer):
         small_cont_1c.add_img(np.random.normal(size=(small_cont_1c.shape + (4,))), channel_dim="foobar", layer="baz")
         crops = list(small_cont_1c.generate_equal_crops(size=13))


### PR DESCRIPTION
Make `spot_diameter` more flexible, also allow to pass an additional kwarg in `generate_spot_crops`

**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Description
<!-- Clearly and concisely describe your changes. This section will be shown in the docs. -->
Enable specifying diameter in :meth:`squidpy.im.ImageContainer.generate_spot_crops`.

## How has this been tested?
<!-- Describe in detail how you've tested your changes. -->
This fixed the gerneration of image dependent on spatial coordinates in my adata, something like this: 
```python
for img, obs in image.generate_spot_crops(adata[adata.obs.id=='37_48_A1'],library_id='37_48_A1-488', return_obs=True, spot_diameter_key='spot_diameter_real'): 
    plt.imshow(img['37_48_A1'].squeeze()[...,:3])
```
where 
```python
```python
>>> adata.uns['spatial']['37_48_A1-488']['spot_diameter_fullres']
{'images': {'lowres': array([[0, 0, 0, ..., 0, 0, 0],
         [0, 0, 0, ..., 0, 0, 0],
         [0, 0, 0, ..., 0, 0, 0],
         ...,
         [0, 0, 0, ..., 0, 0, 0],
         [0, 0, 4, ..., 0, 0, 0],
         [0, 0, 1, ..., 0, 0, 0]], dtype=uint8)},
 'scalefactors': {'pixel_per_um': 3.9686466275780496,
  'pixel_per_um_real': 4.048,
  'resolution': 50,
  'spot_diameter_fullres': 60,
  'spot_diameter_real': 198.4323313789025,
  'tissue_hires_scalef': 1.0,
  'tissue_lowres_scalef': 0.2,
  'upper_left_spot_coord': array([100, 100], dtype=int32)}}
```


## Closes
<!-- If applicable, type `closes #XXXX` in your comment to auto-close the issue that this PR fixes. -->
#513