### PR TITLE
Fix adata subset in ImageContainer

### DIFF
--- a/squidpy/_constants/_pkg_constants.py
+++ b/squidpy/_constants/_pkg_constants.py
@@ -135,7 +135,7 @@ class Key:
             except KeyError:
                 raise KeyError(
                     f"Unable to get the spot diameter from "
-                    f"`adata.uns[{spatial_key!r}][{library_id!r}]['scalefactors'][{spot_diameter_key!r}]]`"
+                    f"`adata.uns[{spatial_key!r}][{library_id!r}]['scalefactors'][{spot_diameter_key!r}].`"
                 ) from None
 
         @classmethod

--- a/squidpy/im/_container.py
+++ b/squidpy/im/_container.py
@@ -1289,7 +1289,6 @@ class ImageContainer(FeatureMixin):
         adjust_interactive: bool = False,
     ) -> AnnData:
         _assert_spatial_basis(adata, spatial_key)
-
         adata = adata.copy()
         s = self.data.attrs.get(Key.img.scale, 1)
         coordinates = adata.obsm[spatial_key]

--- a/squidpy/im/_container.py
+++ b/squidpy/im/_container.py
@@ -260,7 +260,6 @@ class ImageContainer(FeatureMixin):
                   tries to also load the first dimension as channels if the last non-spatial dimension is 1.
                 - a sequence of dimension names matching the shape of ``img``, e.g. ``('y', 'x', 'z', 'channels')``.
                   `'y'`, `'x'` and `'z'` must always be present.
-
         library_id
             Name for each Z-dimension of the image. This should correspond to the ``library_id``
             in :attr:`anndata.AnnData.uns`.

--- a/squidpy/pl/_interactive/_model.py
+++ b/squidpy/pl/_interactive/_model.py
@@ -63,7 +63,7 @@ class ImageModel:
         except KeyError:
             raise KeyError(
                 f"Unable to subset the image container with library ids `{self.library_id}`. "
-                f"Valid container library ids are `{self.container.library_ids}`."
+                f"Valid container library ids are `{self.container.library_ids}`. Please specify a valid `library_id`."
             ) from None
 
     def _update_coords(self) -> None:

--- a/squidpy/pl/_interactive/_model.py
+++ b/squidpy/pl/_interactive/_model.py
@@ -63,7 +63,7 @@ class ImageModel:
         except KeyError:
             raise KeyError(
                 f"Unable to subset the image container with library ids `{self.library_id}`. "
-                f"Valid library ids are `{self.container.library_ids}`."
+                f"Valid container library ids are `{self.container.library_ids}`."
             ) from None
 
     def _update_coords(self) -> None:
@@ -93,11 +93,11 @@ class ImageModel:
         if not len(self.library_id):
             raise ValueError("No library ids have been selected.")
         # invalid library ids from adata are filtered below
-        # invalid library ids from container raise KeyError in __post_init__
+        # invalid library ids from container raise KeyError in `__post_init__` after this call
 
         libraries = self.adata.obs[self.library_key]
         mask = libraries.isin(self.library_id)
-        libraries = libraries[mask]
+        libraries = libraries[mask].cat.remove_unused_categories()
         self.library_id = list(libraries.cat.categories)
 
         self.coordinates = np.c_[libraries.cat.codes.values, self.coordinates[mask]]
@@ -108,3 +108,4 @@ class ImageModel:
                 for lid in libraries
             ]
         )
+        self.adata = self.adata[mask]


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Description
<!-- Clearly and concisely describe your changes. This section will be shown in the docs. -->
Fix not correctly subsetting :class:`anndata.AnnData` when interactively visualizing it.

## How has this been tested?
<!-- Describe in detail how you've tested your changes. -->
```python
import scanpy as sc
import anndata as ad
import squidpy as sq

library_ids = ["V1_Mouse_Brain_Sagittal_Posterior", "V1_Mouse_Brain_Sagittal_Posterior_Section_2"]

adatas, imgs = [], []
use_hires_tiff = False
for library_id in library_ids:
    adatas.append(sc.datasets.visium_sge(library_id, include_hires_tiff=use_hires_tiff))
    adatas[-1].var_names_make_unique()
adata = ad.concat(adatas, uns_merge="only", label="library_id", keys=library_ids, index_unique="-")
img = sq.im.ImageContainer.from_adata(adata, library_id='V1_Mouse_Brain_Sagittal_Posterior_Section_2')

img.interactive(adata, library_key="library_id", library_id="V1_Mouse_Brain_Sagittal_Posterior_Section_2")
```

## Closes
<!-- If applicable, type `closes #XXXX` in your comment to auto-close the issue that this PR fixes. -->
N/A