### PR TITLE
fix res_key in reader

### DIFF
--- a/squidpy/read/_read.py
+++ b/squidpy/read/_read.py
@@ -68,7 +68,7 @@ def visium(
         return adata
 
     adata.uns[Key.uns.spatial][library_id][Key.uns.image_key] = {
-        f"{res}_image": _load_image(path / f"{Key.uns.spatial}/tissue_{res}_image.png") for res in ["hires", "lowres"]
+        res: _load_image(path / f"{Key.uns.spatial}/tissue_{res}_image.png") for res in ["hires", "lowres"]
     }
     adata.uns[Key.uns.spatial][library_id]["scalefactors"] = json.loads(
         (path / f"{Key.uns.spatial}/scalefactors_json.json").read_bytes()

--- a/tests/read/test_visium.py
+++ b/tests/read/test_visium.py
@@ -1,6 +1,7 @@
 from anndata.tests.helpers import assert_adata_equal
 
 from squidpy.read import visium
+from squidpy._constants._pkg_constants import Key
 
 
 def test_read_visium():
@@ -9,6 +10,13 @@ def test_read_visium():
     spec_genome_v3 = visium(h5_file_path, genome="GRCh38", load_images=True)
     nospec_genome_v3 = visium(h5_file_path)
     assert_adata_equal(spec_genome_v3, nospec_genome_v3)
+    adata = spec_genome_v3
+    assert "spatial" in adata.uns.keys()
+    lib_id = list(adata.uns[Key.uns.spatial].keys())[0]
+    assert Key.uns.image_key in adata.uns[Key.uns.spatial][lib_id].keys()
+    assert Key.uns.scalefactor_key in adata.uns[Key.uns.spatial][lib_id].keys()
+    assert Key.uns.image_res_key in adata.uns[Key.uns.spatial][lib_id][Key.uns.image_key]
+    assert Key.uns.size_key in adata.uns[Key.uns.spatial][lib_id][Key.uns.scalefactor_key]
 
 
 def test_read_text():


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Description
Close #536. Set consistent image resolution key in `sq.read.visium`. 

## How has this been tested?
<!-- Describe in detail how you've tested your changes. -->

## Closes
<!-- If applicable, type `closes #XXXX` in your comment to auto-close the issue that this PR fixes. -->
