### PR TITLE
read only images of a specified format in CellComposite,CellLabels

### DIFF
--- a/squidpy/read/_read.py
+++ b/squidpy/read/_read.py
@@ -221,12 +221,15 @@ def nanostring(
             "scalefactors": {"tissue_hires_scalef": 1, "spot_diameter_fullres": 1},
         }
 
+    file_extensions = (".jpg", ".png", ".jpeg", ".tif", ".tiff")
+
     pat = re.compile(r".*_F(\d+)")
     for subdir in ["CellComposite", "CellLabels"]:
         kind = "hires" if subdir == "CellComposite" else "segmentation"
         for fname in os.listdir(path / subdir):
-            fov = str(int(pat.findall(fname)[0]))
-            adata.uns[Key.uns.spatial][fov]["images"][kind] = _load_image(path / subdir / fname)
+            if fname.endswith(file_extensions):
+                fov = str(int(pat.findall(fname)[0]))
+                adata.uns[Key.uns.spatial][fov]["images"][kind] = _load_image(path / subdir / fname)
 
     if fov_file is not None:
         fov_positions = pd.read_csv(path / fov_file, header=0, index_col=fov_key)


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Description
`sq.read.nanostring` reads only image file extensions.

## How has this been tested?
<!-- Describe in detail how you've tested your changes. -->

## Closes
<!-- If applicable, type `closes #XXXX` in your comment to auto-close the issue that this PR fixes. -->
